### PR TITLE
Gracefully handle missing Stripe configuration

### DIFF
--- a/utils/stripe/config.ts
+++ b/utils/stripe/config.ts
@@ -1,18 +1,47 @@
 import Stripe from 'stripe';
 
-export const stripe = new Stripe(
-  process.env.STRIPE_SECRET_KEY_LIVE ?? process.env.STRIPE_SECRET_KEY ?? '',
-  {
-    // https://github.com/stripe/stripe-node#configuration
-    // https://stripe.com/docs/api/versioning
-    // @ts-ignore
-    apiVersion: null,
-    // Register this as an official Stripe plugin.
-    // https://stripe.com/docs/building-plugins#setappinfo
-    appInfo: {
-      name: 'Next.js Subscription Starter',
-      version: '0.0.0',
-      url: 'https://github.com/vercel/nextjs-subscription-payments'
-    }
+const STRIPE_APP_INFO = {
+  name: 'Next.js Subscription Starter',
+  version: '0.0.0',
+  url: 'https://github.com/vercel/nextjs-subscription-payments'
+} as const;
+
+let stripeClient: Stripe | null = null;
+
+export class StripeNotConfiguredError extends Error {
+  constructor() {
+    super(
+      'Stripe secret key is not configured. Set STRIPE_SECRET_KEY or STRIPE_SECRET_KEY_LIVE in your environment to enable Stripe features.'
+    );
+    this.name = 'StripeNotConfiguredError';
   }
-);
+}
+
+export function isStripeConfigured(): boolean {
+  return Boolean(
+    process.env.STRIPE_SECRET_KEY_LIVE ?? process.env.STRIPE_SECRET_KEY
+  );
+}
+
+export function getStripeClient(): Stripe {
+  const secretKey =
+    process.env.STRIPE_SECRET_KEY_LIVE ?? process.env.STRIPE_SECRET_KEY;
+
+  if (!secretKey) {
+    throw new StripeNotConfiguredError();
+  }
+
+  if (!stripeClient) {
+    stripeClient = new Stripe(secretKey, {
+      // https://github.com/stripe/stripe-node#configuration
+      // https://stripe.com/docs/api/versioning
+      // @ts-ignore
+      apiVersion: null,
+      // Register this as an official Stripe plugin.
+      // https://stripe.com/docs/building-plugins#setappinfo
+      appInfo: STRIPE_APP_INFO
+    });
+  }
+
+  return stripeClient;
+}


### PR DESCRIPTION
## Summary
- add a lazily instantiated Stripe client that throws a clear error when required secrets are absent
- guard webhook handlers so they short-circuit with helpful responses instead of crashing if Stripe is not configured
- update Stripe server actions and Supabase helpers to retrieve the client lazily and surface configuration issues cleanly

## Testing
- npm run build *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e492b128b08321bf9e96bbc8a54a9a