### PR TITLE
Add launch readiness manager script

### DIFF
--- a/docs/three-day-launch-plan.md
+++ b/docs/three-day-launch-plan.md
@@ -1,0 +1,67 @@
+# mnnr.app Three-Day Launch Plan
+
+This document captures the hyper-focused three-day plan required to launch **mnnr.app** with production-ready security and functionality. Each day is organized around a clear objective with timeboxed tasks to maintain momentum.
+
+> 💡 **Automation assist:** run `npm run launch:manager` to see an actionable readiness summary that checks environment variables, rate limiting, and security header coverage before you start each day.
+
+## Day 1 – Solidify the Core
+
+**Primary objective:** Deliver a fully functional and secure application foundation.
+
+### Morning (3–4 hours) – Database & Authentication
+- Apply the three Supabase SQL migrations outlined in `APPLY_MIGRATIONS.md`, then verify that Row Level Security (RLS) policies are active.
+- Configure production Supabase and Stripe environment variables in Vercel to avoid exposing service role keys.
+- Test the entire authentication flow: sign-up, email verification, password reset, and session persistence.
+- Execute the admin SQL from `SECURITY_HARDENING_PLAN.md` to enforce deny-by-default RLS on all tables in the public schema.
+
+### Afternoon (2–3 hours) – Payments & User Flow
+- Exercise the Stripe integration end-to-end, including checkout, webhook handling, subscription lifecycle, and failure states; confirm webhook signature validation.
+- Complete a full pilot user journey from application through dashboard access to ensure no critical UX gaps remain.
+
+**End-of-day target:** Database, authentication, and payment subsystems are production-ready.
+
+## Day 2 – Polish and Harden
+
+**Primary objective:** Ship a professionally polished, security-focused experience on the production domain.
+
+### Morning (3–4 hours) – Domain & Legal
+- Point `mnnr.app` to Vercel, confirming DNS propagation and SSL certificate issuance.
+- Add comprehensive security headers (HSTS, X-Frame-Options, Content-Security-Policy, etc.) via middleware.
+- Publish Privacy Policy, Terms of Service, and Refund Policy pages to satisfy compliance expectations and Stripe requirements.
+
+### Afternoon (3–4 hours) – Monitoring & UX Polish
+- Configure analytics and monitoring (e.g., PostHog) for conversion tracking and error visibility.
+- Perform UI/UX sweeps across devices and browsers, refining loading, error, and success states for clarity.
+- Implement rate limiting using Vercel Edge Config with Upstash or Vercel KV for both authenticated and guest traffic.
+
+**End-of-day target:** Production deployment on `mnnr.app` with hardened security posture and refined UX.
+
+## Day 3 – Pre-Launch & Go-Live
+
+**Primary objective:** Validate end-to-end readiness and launch publicly.
+
+### Morning (4 hours) – Testing & Launch Prep
+- Conduct full end-to-end testing—from signup through payment and onboarding—on multiple devices/browsers; validate headers via securityheaders.com.
+- Prepare launch collateral: announcement copy, product screenshots, and social media assets.
+
+### Afternoon – Soft Launch & Monitoring
+- Execute a final smoke test of critical flows prior to announcement.
+- Announce the launch across social channels and relevant communities.
+- Monitor analytics and support channels closely to resolve issues rapidly and engage early adopters.
+
+## Confidence Checklist
+
+Before proceeding, confirm the readiness criteria from `LAUNCH_READINESS_10_10.md`:
+- Availability of 5–6 hours of focused effort per day during the three-day push.
+- Acceptance that the MVP is "good enough" for launch.
+- Willingness to manage user support manually.
+- Database and authentication verified as operational by the end of Day 1.
+
+## Post-Launch Security Enhancements
+
+To align with the "quantum-level" security vision, prioritize the following after launch:
+- Initiate SOC 2 readiness using the roadmap in `SOC2_STARTUP_CHECKLIST.md`, potentially with an automation partner like Vanta.
+- Implement the CI-based security workflow from `SECURITY_HARDENING_PLAN.md` for SBOM generation, SAST scanning, and dependency locking.
+- Ensure the Stripe webhook handler is idempotent to guard against duplicate event processing.
+
+Following this plan keeps the focus on high-impact tasks, enabling a confident, secure launch within three days while setting the stage for ongoing hardening and compliance.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "supabase:generate-migration": "npx supabase db diff | npx supabase migration new",
     "supabase:generate-seed": "npx supabase db dump --data-only -f supabase/seed.sql",
     "supabase:push": "npx supabase db push",
-    "supabase:pull": "npx supabase db pull"
+    "supabase:pull": "npx supabase db pull",
+    "launch:manager": "node scripts/launch-manager.mjs"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
@@ -40,7 +41,7 @@
     "@upstash/ratelimit": "^2.0.6",
     "@upstash/redis": "^1.35.4",
     "@vercel/otel": "^2.0.1",
-  "posthog-js": "^1.140.0",
+    "posthog-js": "^1.140.0",
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",

--- a/scripts/launch-manager.mjs
+++ b/scripts/launch-manager.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const requiredEnvKeys = {
+  production: [
+    'NEXT_PUBLIC_SUPABASE_URL',
+    'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+    'SUPABASE_SERVICE_ROLE_KEY',
+    'STRIPE_SECRET_KEY',
+    'STRIPE_WEBHOOK_SECRET',
+    'POSTHOG_API_KEY',
+    'POSTHOG_HOST'
+  ],
+  shared: [
+    'NEXT_PUBLIC_SITE_URL',
+    'SUPABASE_JWT_SECRET',
+    'VERCEL_PROJECT_ID'
+  ]
+};
+
+const docsByTask = {
+  env: 'VERCEL_DEPLOY_NOW.md',
+  migrations: 'APPLY_MIGRATIONS.md',
+  securityHeaders: 'SECURITY_IMPLEMENTATION_COMPLETE.md',
+  rateLimiting: 'SECURITY_HARDENING_PLAN.md',
+  payments: 'TONIGHT_LAUNCH_CHECKLIST.md',
+  monitoring: 'ANALYTICS_COMPLETE.md'
+};
+
+async function parseEnvFile(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const lines = raw.split(/\r?\n/);
+    const entries = lines
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'))
+      .map((line) => {
+        const index = line.indexOf('=');
+        if (index === -1) return null;
+        const key = line.slice(0, index).trim();
+        const value = line.slice(index + 1).trim();
+        return [key, value.replace(/^"|"$/g, '')];
+      })
+      .filter(Boolean);
+    return new Map(entries);
+  } catch (error) {
+    return null;
+  }
+}
+
+async function loadEnvSources() {
+  const files = [
+    path.join(repoRoot, '.env.production'),
+    path.join(repoRoot, '.env.production.local'),
+    path.join(repoRoot, '.env.local'),
+    path.join(repoRoot, '.env'),
+    path.join(repoRoot, '.env.example')
+  ];
+
+  const results = new Map();
+
+  for (const file of files) {
+    const envMap = await parseEnvFile(file);
+    if (envMap) {
+      results.set(path.basename(file), envMap);
+    }
+  }
+
+  return results;
+}
+
+function getEnvStatus(envSources, envKey) {
+  for (const [, envMap] of envSources) {
+    if (envMap.has(envKey) && envMap.get(envKey)) {
+      return 'present';
+    }
+  }
+  if (process.env[envKey]) {
+    return 'present';
+  }
+  return 'missing';
+}
+
+async function checkEnvConfiguration() {
+  const envSources = await loadEnvSources();
+  const statuses = [];
+
+  for (const [scope, keys] of Object.entries(requiredEnvKeys)) {
+    for (const key of keys) {
+      statuses.push({
+        scope,
+        key,
+        status: getEnvStatus(envSources, key)
+      });
+    }
+  }
+
+  const missing = statuses.filter((entry) => entry.status === 'missing');
+
+  return {
+    statuses,
+    missing,
+    envSources
+  };
+}
+
+async function fileExists(relativePath) {
+  try {
+    await fs.access(path.join(repoRoot, relativePath));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function checkFileContains(relativePath, searchTerms) {
+  try {
+    const filePath = path.join(repoRoot, relativePath);
+    const content = await fs.readFile(filePath, 'utf8');
+    return searchTerms.every((term) => content.includes(term));
+  } catch {
+    return false;
+  }
+}
+
+async function evaluateReadiness() {
+  const [envStatus, hasMigrations, hasSecurityHeaders, hasRateLimiting] = await Promise.all([
+    checkEnvConfiguration(),
+    fileExists('supabase/migrations'),
+    checkFileContains('middleware.ts', [
+      'Strict-Transport-Security',
+      'Content-Security-Policy',
+      'X-Frame-Options'
+    ]),
+    checkFileContains('utils/rate-limit.ts', ['checkRateLimit', 'Redis'])
+  ]);
+
+  const readiness = [];
+
+  readiness.push({
+    id: 'env',
+    label: 'Production environment variables configured',
+    status: envStatus.missing.length === 0 ? 'ready' : 'attention',
+    detail: envStatus
+  });
+
+  readiness.push({
+    id: 'migrations',
+    label: 'Supabase migrations available',
+    status: hasMigrations ? 'ready' : 'attention',
+    detail: hasMigrations
+      ? 'Migrations directory detected.'
+      : 'No migrations directory found. Review APPLY_MIGRATIONS.md.'
+  });
+
+  readiness.push({
+    id: 'securityHeaders',
+    label: 'Security headers enforced in middleware',
+    status: hasSecurityHeaders ? 'ready' : 'attention',
+    detail: hasSecurityHeaders
+      ? 'Middleware includes core security headers.'
+      : 'Update middleware.ts to include security headers.'
+  });
+
+  readiness.push({
+    id: 'rateLimiting',
+    label: 'Enterprise rate limiting utilities present',
+    status: hasRateLimiting ? 'ready' : 'attention',
+    detail: hasRateLimiting
+      ? 'Redis-backed rate limiting utilities detected.'
+      : 'Rate limiting utilities missing. See SECURITY_HARDENING_PLAN.md.'
+  });
+
+  return readiness;
+}
+
+function formatStatus(status) {
+  return status === 'ready' ? '✅ READY' : '⚠️ ATTENTION NEEDED';
+}
+
+function formatEnvTable(envStatus) {
+  const rows = envStatus.statuses.map(({ scope, key, status }) => {
+    const label = status === 'present' ? '✅' : '⚠️';
+    return `${label} ${key}${scope !== 'shared' ? ` (${scope})` : ''}`;
+  });
+
+  return rows.join('\n');
+}
+
+function printDocsReminder(taskId) {
+  const doc = docsByTask[taskId];
+  if (doc) {
+    console.log(`   ↳ Reference: ${doc}`);
+  }
+}
+
+async function main() {
+  console.log('🚀 mnnr.app Launch Manager');
+  console.log('============================\n');
+
+  const readiness = await evaluateReadiness();
+  const envStatus = readiness.find((item) => item.id === 'env').detail;
+
+  console.log('Environment Configuration');
+  console.log('--------------------------');
+  console.log(formatEnvTable(envStatus));
+  if (envStatus.missing.length > 0) {
+    console.log('\nMissing variables:');
+    envStatus.missing.forEach((entry) => {
+      console.log(` - ${entry.key} [${entry.scope}]`);
+    });
+  }
+  console.log('\n');
+
+  console.log('Launch Critical Path');
+  console.log('---------------------');
+  readiness
+    .filter((item) => item.id !== 'env')
+    .forEach((item) => {
+      console.log(`${formatStatus(item.status)} ${item.label}`);
+      if (typeof item.detail === 'string') {
+        console.log(`   ${item.detail}`);
+      }
+      printDocsReminder(item.id);
+      console.log('');
+    });
+
+  console.log('Next Steps Guidance');
+  console.log('--------------------');
+  console.log('1. Apply database migrations and confirm RLS policies.');
+  console.log('2. Verify Stripe credentials and run webhook tests.');
+  console.log('3. Confirm legal pages and analytics scripts are deployed.');
+  console.log('4. Run end-to-end smoke test prior to launch.');
+
+  console.log('\nNeed more detail? Use the referenced documentation for step-by-step instructions.');
+}
+
+main().catch((error) => {
+  console.error('Launch manager failed to run:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a launch manager CLI script that audits environment configuration, security headers, and rate limiting readiness
- expose the CLI through `npm run launch:manager` and document the automation shortcut in the launch plan

## Testing
- node scripts/launch-manager.mjs

------
https://chatgpt.com/codex/tasks/task_b_68e580d8763883218e193fca89893119