### PR TITLE
Automate launch sprint execution and add refund policy

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -7,6 +7,7 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  console.error('Global error boundary triggered', error);
   return (
     <html>
       <body>

--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable react/no-unescaped-entities */
+// Legal text intentionally keeps standard punctuation for readability.
+
 export const metadata = {
   title: 'Privacy Policy | MNNR.APP',
   description: 'Privacy Policy for MNNR - AI-Powered Pilot Recruiting Platform'

--- a/app/legal/refund/page.tsx
+++ b/app/legal/refund/page.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable react/no-unescaped-entities */
+// Legal text intentionally keeps standard punctuation for readability.
+
+export const metadata = {
+  title: 'Refund Policy | MNNR.APP',
+  description: 'Refund and cancellation policy for MNNR subscriptions and services'
+};
+
+export default function RefundPolicyPage() {
+  return (
+    <div className="container mx-auto px-4 py-16 max-w-4xl">
+      <h1 className="text-4xl font-bold mb-8">Refund Policy</h1>
+
+      <p className="text-sm text-gray-600 mb-8">
+        <strong>Last Updated:</strong> October 6, 2025
+      </p>
+
+      <div className="prose prose-lg max-w-none">
+        <h2>1. Overview</h2>
+        <p>
+          MNNR subscriptions are designed to provide immediate access to pilot recruiting tools, secure
+          data integrations, and premium support. Because value is delivered at signup, refunds are
+          limited to the situations described below.
+        </p>
+
+        <h2>2. Eligibility for Refunds</h2>
+        <ul>
+          <li>
+            <strong>Duplicate charges:</strong> If you were accidentally billed more than once for the
+            same subscription period, contact us within 14 days and we will reverse the duplicate
+            charge.
+          </li>
+          <li>
+            <strong>Service outages:</strong> If platform downtime exceeds 24 consecutive hours outside of
+            scheduled maintenance windows, you may request a pro-rated credit for the affected billing
+            period.
+          </li>
+          <li>
+            <strong>Onboarding guarantee:</strong> If you complete the onboarding checklist within 30 days
+            and the core features outlined in your plan are not available, we will refund your most
+            recent payment.
+          </li>
+        </ul>
+
+        <h2>3. Non-Refundable Items</h2>
+        <ul>
+          <li>Completed consulting or implementation services</li>
+          <li>Third-party fees (for example, Stripe processing costs)</li>
+          <li>Usage-based charges that were already incurred before cancellation</li>
+        </ul>
+
+        <h2>4. Cancellation Policy</h2>
+        <p>
+          You can cancel your subscription at any time from the billing dashboard. Cancellation stops
+          future renewals but does not issue an automatic refund for prior charges unless one of the
+          eligibility criteria above is met.
+        </p>
+
+        <h2>5. How to Request a Refund</h2>
+        <ol>
+          <li>Email <a href="mailto:billing@mnnr.app">billing@mnnr.app</a> from your account address.</li>
+          <li>Include your workspace name, recent invoice ID, and reason for the request.</li>
+          <li>Attach any supporting evidence (for example, duplicate receipt, uptime log).</li>
+        </ol>
+        <p>
+          We review refund requests within five business days. Approved refunds are issued back to the
+          original payment method.
+        </p>
+
+        <h2>6. Chargebacks</h2>
+        <p>
+          Filing a chargeback without contacting MNNR first may result in immediate suspension of your
+          account and loss of access to pilot data. We work directly with Stripe to resolve disputes and
+          can typically address billing concerns faster when you reach out to us first.
+        </p>
+
+        <h2>7. Contact</h2>
+        <p>
+          Questions about this policy? Reach our billing team at{' '}
+          <a href="mailto:billing@mnnr.app">billing@mnnr.app</a>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/legal/terms/page.tsx
+++ b/app/legal/terms/page.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable react/no-unescaped-entities */
+// Legal text intentionally keeps standard punctuation for readability.
+
 export const metadata = {
   title: 'Terms of Service | MNNR.APP',
   description: 'Terms of Service for MNNR - AI-Powered Pilot Recruiting Platform'

--- a/components/ui/Footer/Footer.tsx
+++ b/components/ui/Footer/Footer.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import Link from 'next/link';
 
 import Logo from '@/components/icons/Logo';

--- a/components/ui/Navbar/Navbar.tsx
+++ b/components/ui/Navbar/Navbar.tsx
@@ -7,11 +7,12 @@ export default async function Navbar() {
 
   try {
     const supabase = createClient();
-    const response = await Promise.race([
-      supabase.auth.getUser(),
-      new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), 2000))
-    ]);
-    user = (response as any)?.data?.user || null;
+    const getUserPromise = supabase.auth.getUser();
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Timeout')), 2000)
+    );
+    const response = await Promise.race([getUserPromise, timeout]);
+    user = response.data.user ?? null;
   } catch (error) {
     console.warn('Failed to get user, continuing without auth:', error);
   }

--- a/docs/three-day-launch-plan.md
+++ b/docs/three-day-launch-plan.md
@@ -1,0 +1,56 @@
+# mnnr.app Launch Sprint (One-Day Compression)
+
+This document compresses the original three-day launch playbook into a single, high-intensity sprint so you can ship **mnnr.app** today without sacrificing security or polish. Every block includes explicit tasks, recommended owners, and linked references so nothing slips.
+
+> 💡 **Automation assist:** run `npm run launch:execute` to automatically audit migrations, security, payments, analytics, and production builds. Follow up with `npm run launch:manager -- --accelerated` for the hour-by-hour checklist once the executor reports green.
+
+## Hour 0–1 — Launch Kickoff & Guardrails
+- Run `npm run launch:manager -- --accelerated` to surface gaps in environment variables, migrations, security headers, rate limiting, legal policies, analytics, and outstanding checklist items.
+- Patch production environment variables inside Vercel (Supabase + Stripe) so no secrets leak.
+- Stage the `SECURITY_HARDENING_PLAN.md` SQL to enable deny-by-default RLS immediately after migrations.
+
+## Hour 1–3 — Database & Authentication Hardening
+- Apply all Supabase migrations (`APPLY_MIGRATIONS.md`) and confirm RLS policies are active.
+- Execute the admin SQL to enforce deny-by-default RLS on the public schema.
+- Smoke test authentication: sign-up, email verification, password reset, and persistent sessions.
+
+## Hour 3–5 — Payments & Billing Validation
+- Verify Stripe keys, run checkout, confirm webhook signature validation, and ensure subscription lifecycle events persist correctly.
+- Review webhook handler idempotency so duplicate events never double-charge or desync state.
+
+## Hour 5–7 — Domain, Security Headers & Legal
+- Point `mnnr.app` to Vercel, confirm SSL certificate issuance, and lock in DNS propagation.
+- Update middleware to include HSTS, CSP, X-Frame-Options, and related headers (`SECURITY_IMPLEMENTATION_COMPLETE.md`).
+- Publish Privacy Policy, Terms of Service, and Refund Policy pages (required for Stripe compliance).
+
+## Hour 7–8 — Analytics, Monitoring & Rate Limiting
+- Configure PostHog (or equivalent) using production keys, ensuring error tracking and conversion funnels are live.
+- Enable rate limiting using Vercel Edge Config + Upstash/Vercel KV so both authenticated and anonymous traffic are protected.
+
+## Hour 8–9 — UX Polish & Multi-Device QA
+- Review the UI on mobile, tablet, and desktop across major browsers, polishing loading, success, and error states.
+- Confirm onboarding flows, dashboards, and legal pages render correctly and quickly.
+
+## Hour 9–10 — End-to-End Testing & Launch Collateral
+- Perform a full end-to-end run: new signup → payment → onboarding → dashboard access → cancellation/refund path.
+- Use `securityheaders.com` (or similar) to validate deployed headers.
+- Prepare launch copy, screenshots, and social assets so announcement can happen immediately after final smoke test.
+
+## Hour 10+ — Launch Execution & Monitoring
+- Execute a final smoke test, then push the announcement on social channels and communities.
+- Monitor analytics dashboards, Supabase logs, and Stripe alerts in real time to resolve issues swiftly.
+
+## Confidence Gate
+Before flipping the switch, confirm the readiness criteria from `LAUNCH_READINESS_10_10.md`:
+- You have at least 10 focused hours today.
+- You are comfortable shipping a "good enough" MVP and iterating live.
+- You can personally handle support escalations during the launch window.
+- Database, authentication, payments, and legal artifacts all passed QA in the steps above.
+
+## Post-Launch Security Enhancements
+To stay aligned with the "quantum-level" security vision, queue these follow-ups immediately after launch:
+- Kick off SOC 2 readiness using `SOC2_STARTUP_CHECKLIST.md` (consider Vanta or similar for automation).
+- Wire the CI/CD supply-chain safeguards described in `SECURITY_HARDENING_PLAN.md` (SBOM, SAST, dependency locking).
+- Validate the Stripe webhook handler remains idempotent as you add more billing events.
+
+Executing these blocks sequentially delivers the complete three-day roadmap in a single focused day, preserving enterprise security commitments while getting mnnr.app live today.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "supabase:generate-migration": "npx supabase db diff | npx supabase migration new",
     "supabase:generate-seed": "npx supabase db dump --data-only -f supabase/seed.sql",
     "supabase:push": "npx supabase db push",
-    "supabase:pull": "npx supabase db pull"
+    "supabase:pull": "npx supabase db pull",
+    "launch:manager": "node scripts/launch-manager.mjs",
+    "launch:execute": "node scripts/launch-executor.mjs"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
@@ -40,7 +42,7 @@
     "@upstash/ratelimit": "^2.0.6",
     "@upstash/redis": "^1.35.4",
     "@vercel/otel": "^2.0.1",
-  "posthog-js": "^1.140.0",
+    "posthog-js": "^1.140.0",
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",

--- a/scripts/launch-executor.mjs
+++ b/scripts/launch-executor.mjs
@@ -1,0 +1,355 @@
+#!/usr/bin/env node
+import fs from 'fs/promises';
+import path from 'path';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import {
+  gatherLaunchReadinessData,
+  printAcceleratedTimeline
+} from './launch-manager.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const statusMeta = {
+  success: { symbol: '✅', label: 'Complete' },
+  warn: { symbol: '⚠️', label: 'Needs follow-up' },
+  fail: { symbol: '❌', label: 'Failed' },
+  skipped: { symbol: '➖', label: 'Skipped' }
+};
+
+function formatStatus(status) {
+  const meta = statusMeta[status] ?? statusMeta.warn;
+  return `${meta.symbol} ${meta.label}`;
+}
+
+async function runCommand(command, args = []) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      stdio: 'inherit',
+      shell: false,
+      env: process.env
+    });
+
+    child.on('error', (error) => {
+      resolve({ code: null, error });
+    });
+
+    child.on('close', (code) => {
+      resolve({ code });
+    });
+  });
+}
+
+async function runBaselineScan() {
+  const data = await gatherLaunchReadinessData();
+  const { readiness, envStatus, checklistGaps } = data;
+
+  if (!envStatus) {
+    return { status: 'fail', detail: 'Launch manager missing environment readiness entry.' };
+  }
+
+  const attention = readiness.filter((item) => item.status !== 'ready');
+  const nonEnvAttention = attention.filter((item) => item.id !== 'env');
+  const detailParts = [];
+
+  if (envStatus.missing.length > 0) {
+    detailParts.push(`Missing env vars: ${envStatus.missing.map((entry) => entry.key).join(', ')}`);
+  }
+
+  if (nonEnvAttention.length > 0) {
+    detailParts.push(
+      `Outstanding systems: ${nonEnvAttention.map((item) => item.label).join('; ')}`
+    );
+  }
+
+  if (checklistGaps.length > 0) {
+    detailParts.push(
+      `Checklist TODOs remaining in ${checklistGaps
+        .map((gap) => gap.source.label)
+        .join(', ')}`
+    );
+  }
+
+  const status =
+    envStatus.missing.length === 0 && nonEnvAttention.length === 0 && checklistGaps.length === 0
+      ? 'success'
+      : 'warn';
+
+  return {
+    status,
+    detail:
+      detailParts.length > 0
+        ? detailParts.join(' | ')
+        : 'All tracked launch gates are satisfied. Run migrations + payments validation next.',
+    data
+  };
+}
+
+async function runRlsVerification() {
+  try {
+    const migrationsDir = path.join(repoRoot, 'supabase', 'migrations');
+    const files = (await fs.readdir(migrationsDir)).filter((file) => file.endsWith('.sql'));
+
+    if (files.length === 0) {
+      return {
+        status: 'fail',
+        detail: 'No Supabase SQL migrations were found. Review APPLY_MIGRATIONS.md.'
+      };
+    }
+
+    let rlsFiles = 0;
+    let policyCount = 0;
+
+    for (const file of files) {
+      const content = await fs.readFile(path.join(migrationsDir, file), 'utf8');
+      if (/enable\s+row\s+level\s+security/i.test(content)) {
+        rlsFiles += 1;
+      }
+      const matches = content.match(/create\s+policy/gi);
+      if (matches) {
+        policyCount += matches.length;
+      }
+    }
+
+    const detail = `Scanned ${files.length} migrations · ${rlsFiles} enforce RLS · ${policyCount} policy statements detected.`;
+    const status = rlsFiles > 0 && policyCount > 0 ? 'success' : 'warn';
+
+    return {
+      status,
+      detail: status === 'success' ? detail : `${detail} Add deny-by-default coverage before launch.`
+    };
+  } catch (error) {
+    return {
+      status: 'fail',
+      detail: `Unable to inspect Supabase migrations: ${(error instanceof Error ? error.message : String(error))}`
+    };
+  }
+}
+
+async function runPaymentsVerification() {
+  try {
+    const webhookPath = path.join(repoRoot, 'app', 'api', 'webhooks', 'route.ts');
+    const content = await fs.readFile(webhookPath, 'utf8');
+
+    const requiredSnippets = [
+      'stripe.webhooks.constructEvent',
+      'createRateLimitResponse',
+      "supabase\n        .from('stripe_events')",
+      'manageSubscriptionStatusChange',
+      'logger.webhook'
+    ];
+
+    const missing = requiredSnippets.filter((snippet) => !content.includes(snippet));
+
+    if (missing.length > 0) {
+      return {
+        status: 'warn',
+        detail: `Stripe webhook handler missing critical safeguards: ${missing.join(', ')}`
+      };
+    }
+
+    return {
+      status: 'success',
+      detail: 'Stripe webhook enforces signatures, rate limits, idempotency, and subscription sync.'
+    };
+  } catch (error) {
+    return {
+      status: 'fail',
+      detail: `Stripe webhook route missing or unreadable: ${(error instanceof Error ? error.message : String(error))}`
+    };
+  }
+}
+
+async function runSecurityAndLegalVerification() {
+  const headerChecks = [
+    'Strict-Transport-Security',
+    'Content-Security-Policy',
+    'X-Frame-Options',
+    'Permissions-Policy'
+  ];
+
+  const legalPages = [
+    path.join(repoRoot, 'app', 'legal', 'privacy', 'page.tsx'),
+    path.join(repoRoot, 'app', 'legal', 'terms', 'page.tsx'),
+    path.join(repoRoot, 'app', 'legal', 'refund', 'page.tsx')
+  ];
+
+  try {
+    const middleware = await fs.readFile(path.join(repoRoot, 'middleware.ts'), 'utf8');
+    const missingHeaders = headerChecks.filter((header) => !middleware.includes(header));
+
+    const missingLegal = [];
+    for (const legalPath of legalPages) {
+      try {
+        const stat = await fs.stat(legalPath);
+        if (!stat.isFile()) {
+          missingLegal.push(path.relative(repoRoot, legalPath));
+        }
+      } catch {
+        missingLegal.push(path.relative(repoRoot, legalPath));
+      }
+    }
+
+    if (missingHeaders.length === 0 && missingLegal.length === 0) {
+      return {
+        status: 'success',
+        detail: 'Security headers hardened and all legal policy pages present.'
+      };
+    }
+
+    const issues = [];
+    if (missingHeaders.length > 0) {
+      issues.push(`Headers: ${missingHeaders.join(', ')}`);
+    }
+    if (missingLegal.length > 0) {
+      issues.push(`Legal pages missing: ${missingLegal.join(', ')}`);
+    }
+
+    const status = missingLegal.length > 0 ? 'fail' : 'warn';
+
+    return {
+      status,
+      detail: issues.join(' | ')
+    };
+  } catch (error) {
+    return {
+      status: 'fail',
+      detail: `Unable to validate middleware security headers: ${(error instanceof Error ? error.message : String(error))}`
+    };
+  }
+}
+
+async function runAnalyticsAndRateLimitVerification() {
+  try {
+    const analytics = await fs.readFile(path.join(repoRoot, 'providers', 'PostHogProvider.tsx'), 'utf8');
+    const rateLimit = await fs.readFile(path.join(repoRoot, 'utils', 'rate-limit.ts'), 'utf8');
+
+    const analyticsSnippets = ['posthog.init', 'PostHogProvider', 'analytics.track'];
+    const rateLimitSnippets = ['@upstash/ratelimit', 'Redis', 'checkRateLimit'];
+
+    const missingAnalytics = analyticsSnippets.filter((snippet) => !analytics.includes(snippet));
+    const missingRateLimit = rateLimitSnippets.filter((snippet) => !rateLimit.includes(snippet));
+
+    if (missingAnalytics.length === 0 && missingRateLimit.length === 0) {
+      return {
+        status: 'success',
+        detail: 'Analytics provider and Redis-backed rate limiting utilities are wired up.'
+      };
+    }
+
+    const issues = [];
+    if (missingAnalytics.length > 0) {
+      issues.push(`Analytics gaps: ${missingAnalytics.join(', ')}`);
+    }
+    if (missingRateLimit.length > 0) {
+      issues.push(`Rate limiting gaps: ${missingRateLimit.join(', ')}`);
+    }
+
+    return {
+      status: 'warn',
+      detail: issues.join(' | ')
+    };
+  } catch (error) {
+    return {
+      status: 'fail',
+      detail: `Failed to inspect analytics or rate limiting utilities: ${(error instanceof Error ? error.message : String(error))}`
+    };
+  }
+}
+
+async function runBuildValidation() {
+  const lint = await runCommand('npm', ['run', 'lint']);
+  if (lint.code !== 0) {
+    return {
+      status: 'fail',
+      detail: 'npm run lint failed. Fix lint errors before launch.'
+    };
+  }
+
+  const build = await runCommand('npm', ['run', 'build']);
+  if (build.code !== 0) {
+    return {
+      status: 'fail',
+      detail: 'npm run build failed. Resolve build issues before launch.'
+    };
+  }
+
+  return {
+    status: 'success',
+    detail: 'Lint and production build completed successfully.'
+  };
+}
+
+async function main() {
+  console.log('🛠️  Launch Executor — compressing the single-day plan into verifiable actions');
+  console.log('==========================================================================\n');
+
+  const tasks = [
+    { id: 'baseline', label: 'Baseline readiness scan', runner: runBaselineScan },
+    { id: 'rls', label: 'Database migrations & RLS enforcement', runner: runRlsVerification },
+    { id: 'payments', label: 'Stripe webhook hardening audit', runner: runPaymentsVerification },
+    { id: 'securityLegal', label: 'Security headers & legal policy check', runner: runSecurityAndLegalVerification },
+    { id: 'analytics', label: 'Analytics & rate limiting verification', runner: runAnalyticsAndRateLimitVerification },
+    { id: 'build', label: 'Production lint + build validation', runner: runBuildValidation }
+  ];
+
+  const results = [];
+
+  for (const task of tasks) {
+    console.log(`▶️  ${task.label}`);
+    try {
+      const result = await task.runner();
+      results.push({ ...result, id: task.id, label: task.label });
+      console.log(`   ${formatStatus(result.status)}`);
+      if (result.detail) {
+        console.log(`   ${result.detail}`);
+      }
+      console.log('');
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      results.push({ status: 'fail', detail, id: task.id, label: task.label });
+      console.log(`   ${formatStatus('fail')}`);
+      console.log(`   ${detail}`);
+      console.log('');
+    }
+  }
+
+  const failures = results.filter((result) => result.status === 'fail');
+  const warnings = results.filter((result) => result.status === 'warn');
+
+  console.log('Summary');
+  console.log('-------');
+  console.log(`Completed: ${results.length - failures.length - warnings.length}`);
+  console.log(`Warnings: ${warnings.length}`);
+  console.log(`Failures: ${failures.length}`);
+
+  if (warnings.length > 0 || failures.length > 0) {
+    console.log('\nRecommended follow-up:');
+    warnings.forEach((warning) => {
+      console.log(` - ⚠️  ${warning.label}: ${warning.detail}`);
+    });
+    failures.forEach((failure) => {
+      console.log(` - ❌ ${failure.label}: ${failure.detail}`);
+    });
+    console.log('\nUse npm run launch:manager -- --accelerated for the timeboxed action plan.');
+    console.log('The accelerated schedule is included below for quick reference:\n');
+    printAcceleratedTimeline();
+  }
+
+  const exitCode = failures.length > 0 ? 1 : 0;
+  if (exitCode === 0) {
+    console.log('\n✅ All automated launch gates passed. Execute the external launch actions and go live.');
+  } else {
+    console.log('\n⚠️  Resolve the highlighted items before proceeding with launch.');
+  }
+
+  process.exit(exitCode);
+}
+
+main().catch((error) => {
+  console.error('Launch executor failed:', error);
+  process.exit(1);
+});

--- a/scripts/launch-manager.mjs
+++ b/scripts/launch-manager.mjs
@@ -1,0 +1,515 @@
+#!/usr/bin/env node
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+function parseLaunchManagerArgs(argv = []) {
+  const normalized = new Set(argv);
+  return {
+    help: normalized.has('--help') || normalized.has('-h'),
+    accelerated: normalized.has('--accelerated') || normalized.has('-a')
+  };
+}
+
+const requiredEnvKeys = {
+  production: [
+    'NEXT_PUBLIC_SUPABASE_URL',
+    'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+    'SUPABASE_SERVICE_ROLE_KEY',
+    'STRIPE_SECRET_KEY',
+    'STRIPE_WEBHOOK_SECRET',
+    'POSTHOG_API_KEY',
+    'POSTHOG_HOST'
+  ],
+  shared: [
+    'NEXT_PUBLIC_SITE_URL',
+    'SUPABASE_JWT_SECRET',
+    'VERCEL_PROJECT_ID'
+  ]
+};
+
+const docsByTask = {
+  env: 'VERCEL_DEPLOY_NOW.md',
+  migrations: 'APPLY_MIGRATIONS.md',
+  securityHeaders: 'SECURITY_IMPLEMENTATION_COMPLETE.md',
+  rateLimiting: 'SECURITY_HARDENING_PLAN.md',
+  legalPages: 'TONIGHT_LAUNCH_CHECKLIST.md',
+  analytics: 'ANALYTICS_COMPLETE.md'
+};
+
+const checklistSources = [
+  {
+    id: 'launchReadiness',
+    label: 'Launch Readiness 10/10',
+    path: 'LAUNCH_READINESS_10_10.md'
+  },
+  {
+    id: 'tonightChecklist',
+    label: 'Tonight Launch Checklist',
+    path: 'TONIGHT_LAUNCH_CHECKLIST.md'
+  },
+  {
+    id: 'securityHardening',
+    label: 'Security Hardening Plan',
+    path: 'SECURITY_HARDENING_PLAN.md'
+  }
+];
+
+const legalPages = [
+  {
+    path: 'app/legal/privacy/page.tsx',
+    label: 'Privacy Policy page'
+  },
+  {
+    path: 'app/legal/terms/page.tsx',
+    label: 'Terms of Service page'
+  },
+  {
+    path: 'app/legal/refund/page.tsx',
+    label: 'Refund Policy page'
+  }
+];
+
+async function parseEnvFile(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const lines = raw.split(/\r?\n/);
+    const entries = lines
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'))
+      .map((line) => {
+        const index = line.indexOf('=');
+        if (index === -1) return null;
+        const key = line.slice(0, index).trim();
+        const value = line.slice(index + 1).trim();
+        return [key, value.replace(/^"|"$/g, '')];
+      })
+      .filter(Boolean);
+    return new Map(entries);
+  } catch (error) {
+    return null;
+  }
+}
+
+async function loadEnvSources() {
+  const files = [
+    path.join(repoRoot, '.env.production'),
+    path.join(repoRoot, '.env.production.local'),
+    path.join(repoRoot, '.env.local'),
+    path.join(repoRoot, '.env'),
+    path.join(repoRoot, '.env.example')
+  ];
+
+  const results = new Map();
+
+  for (const file of files) {
+    const envMap = await parseEnvFile(file);
+    if (envMap) {
+      results.set(path.basename(file), envMap);
+    }
+  }
+
+  return results;
+}
+
+function getEnvStatus(envSources, envKey) {
+  for (const [, envMap] of envSources) {
+    if (envMap.has(envKey) && envMap.get(envKey)) {
+      return 'present';
+    }
+  }
+  if (process.env[envKey]) {
+    return 'present';
+  }
+  return 'missing';
+}
+
+async function checkEnvConfiguration() {
+  const envSources = await loadEnvSources();
+  const statuses = [];
+
+  for (const [scope, keys] of Object.entries(requiredEnvKeys)) {
+    for (const key of keys) {
+      statuses.push({
+        scope,
+        key,
+        status: getEnvStatus(envSources, key)
+      });
+    }
+  }
+
+  const missing = statuses.filter((entry) => entry.status === 'missing');
+
+  return {
+    statuses,
+    missing,
+    envSources
+  };
+}
+
+async function fileExists(relativePath) {
+  try {
+    await fs.access(path.join(repoRoot, relativePath));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function checkFileContains(relativePath, searchTerms) {
+  try {
+    const filePath = path.join(repoRoot, relativePath);
+    const content = await fs.readFile(filePath, 'utf8');
+    return searchTerms.every((term) => content.includes(term));
+  } catch {
+    return false;
+  }
+}
+
+function extractOutstandingChecklistItems(content) {
+  const lines = content.split(/\r?\n/);
+  const outstanding = [];
+  let currentHeading = null;
+
+  const headingRegex = /^(#{1,6})\s+(.+)$/;
+  const taskRegexes = [
+    /^\s*[-*]\s+\[ \]\s+(.*)$/,
+    /^\s*\d+\.\s+\[ \]\s+(.*)$/
+  ];
+
+  for (const line of lines) {
+    const headingMatch = line.match(headingRegex);
+    if (headingMatch) {
+      currentHeading = headingMatch[2].trim();
+      continue;
+    }
+
+    for (const regex of taskRegexes) {
+      const taskMatch = line.match(regex);
+      if (taskMatch) {
+        outstanding.push({
+          text: taskMatch[1].trim(),
+          heading: currentHeading || null
+        });
+        break;
+      }
+    }
+  }
+
+  return outstanding;
+}
+
+async function loadChecklistGaps(relativePath) {
+  try {
+    const filePath = path.join(repoRoot, relativePath);
+    const content = await fs.readFile(filePath, 'utf8');
+    return extractOutstandingChecklistItems(content);
+  } catch {
+    return [];
+  }
+}
+
+export async function collectChecklistGaps() {
+  const results = [];
+
+  for (const source of checklistSources) {
+    const items = await loadChecklistGaps(source.path);
+    if (items.length > 0) {
+      results.push({
+        source,
+        items
+      });
+    }
+  }
+
+  return results;
+}
+
+export async function evaluateReadiness() {
+  const [
+    envStatus,
+    hasMigrations,
+    hasSecurityHeaders,
+    hasRateLimiting,
+    legalStatus,
+    hasAnalytics
+  ] = await Promise.all([
+    checkEnvConfiguration(),
+    fileExists('supabase/migrations'),
+    checkFileContains('middleware.ts', [
+      'Strict-Transport-Security',
+      'Content-Security-Policy',
+      'X-Frame-Options'
+    ]),
+    checkFileContains('utils/rate-limit.ts', ['checkRateLimit', 'Redis']),
+    Promise.all(legalPages.map((entry) => fileExists(entry.path))),
+    checkFileContains('providers/PostHogProvider.tsx', ['PostHogProvider', 'posthog-js'])
+  ]);
+
+  const readiness = [];
+
+  readiness.push({
+    id: 'env',
+    label: 'Production environment variables configured',
+    status: envStatus.missing.length === 0 ? 'ready' : 'attention',
+    detail: envStatus
+  });
+
+  readiness.push({
+    id: 'migrations',
+    label: 'Supabase migrations available',
+    status: hasMigrations ? 'ready' : 'attention',
+    detail: hasMigrations
+      ? 'Migrations directory detected.'
+      : 'No migrations directory found. Review APPLY_MIGRATIONS.md.'
+  });
+
+  readiness.push({
+    id: 'securityHeaders',
+    label: 'Security headers enforced in middleware',
+    status: hasSecurityHeaders ? 'ready' : 'attention',
+    detail: hasSecurityHeaders
+      ? 'Middleware includes core security headers.'
+      : 'Update middleware.ts to include security headers.'
+  });
+
+  readiness.push({
+    id: 'rateLimiting',
+    label: 'Enterprise rate limiting utilities present',
+    status: hasRateLimiting ? 'ready' : 'attention',
+    detail: hasRateLimiting
+      ? 'Redis-backed rate limiting utilities detected.'
+      : 'Rate limiting utilities missing. See SECURITY_HARDENING_PLAN.md.'
+  });
+
+  const missingLegalPages = legalPages
+    .map((entry, index) => ({ entry, exists: legalStatus[index] }))
+    .filter((item) => !item.exists)
+    .map((item) => item.entry.label);
+
+  readiness.push({
+    id: 'legalPages',
+    label: 'Legal policy pages published',
+    status: missingLegalPages.length === 0 ? 'ready' : 'attention',
+    detail:
+      missingLegalPages.length === 0
+        ? 'Privacy, terms, and refund policy pages detected.'
+        : `Missing: ${missingLegalPages.join(', ')}`
+  });
+
+  readiness.push({
+    id: 'analytics',
+    label: 'Analytics instrumentation ready',
+    status: hasAnalytics ? 'ready' : 'attention',
+    detail: hasAnalytics
+      ? 'PostHog provider present – configure keys to activate.'
+      : 'PostHog provider not detected. Review ANALYTICS_COMPLETE.md.'
+  });
+
+  return readiness;
+}
+
+function formatStatus(status) {
+  return status === 'ready' ? '✅ READY' : '⚠️ ATTENTION NEEDED';
+}
+
+function formatEnvTable(envStatus) {
+  const rows = envStatus.statuses.map(({ scope, key, status }) => {
+    const label = status === 'present' ? '✅' : '⚠️';
+    return `${label} ${key}${scope !== 'shared' ? ` (${scope})` : ''}`;
+  });
+
+  return rows.join('\n');
+}
+
+function printDocsReminder(taskId, output = console) {
+  const doc = docsByTask[taskId];
+  if (doc) {
+    output.log(`   ↳ Reference: ${doc}`);
+  }
+}
+
+export function printAcceleratedTimeline(output = console) {
+  const blocks = [
+    {
+      label: 'Hour 0–1 — Launch Kickoff & Guardrails',
+      tasks: [
+        'Run npm run launch:manager -- --accelerated to capture gaps before you start.',
+        'Patch production Supabase + Stripe environment variables inside Vercel.',
+        'Queue the SECURITY_HARDENING_PLAN.md SQL so deny-by-default RLS is ready immediately after migrations.'
+      ]
+    },
+    {
+      label: 'Hour 1–3 — Database & Authentication Hardening',
+      tasks: [
+        'Apply all Supabase migrations and confirm RLS policies are active (APPLY_MIGRATIONS.md).',
+        'Execute the deny-by-default RLS SQL across the public schema.',
+        'Exercise signup, email verification, password reset, and session persistence flows.'
+      ]
+    },
+    {
+      label: 'Hour 3–5 — Payments & Billing Validation',
+      tasks: [
+        'Validate Stripe credentials, run checkout, and confirm webhook signature enforcement.',
+        'Inspect webhook handler idempotency so duplicate events cannot desync state.'
+      ]
+    },
+    {
+      label: 'Hour 5–7 — Domain, Security Headers & Legal',
+      tasks: [
+        'Point mnnr.app to Vercel and verify SSL provisioning.',
+        'Lock in HSTS, CSP, X-Frame-Options, and related headers in middleware.ts.',
+        'Publish Privacy Policy, Terms of Service, and Refund Policy pages.'
+      ]
+    },
+    {
+      label: 'Hour 7–8 — Analytics, Monitoring & Rate Limiting',
+      tasks: [
+        'Configure PostHog (or equivalent) production keys for analytics + error visibility.',
+        'Enable Redis-backed rate limiting via Vercel Edge Config + Upstash/Vercel KV.'
+      ]
+    },
+    {
+      label: 'Hour 8–9 — UX Polish & Multi-Device QA',
+      tasks: [
+        'Review mobile/desktop/tablet flows, tightening loading, success, and error states.',
+        'Confirm onboarding, dashboard, and legal pages render crisply across browsers.'
+      ]
+    },
+    {
+      label: 'Hour 9–10 — End-to-End Testing & Launch Collateral',
+      tasks: [
+        'Run a full journey: signup → payment → onboarding → dashboard → cancellation/refund.',
+        'Validate production headers via securityheaders.com (or similar).',
+        'Assemble announcement copy, screenshots, and social assets.'
+      ]
+    },
+    {
+      label: 'Hour 10+ — Launch Execution & Monitoring',
+      tasks: [
+        'Perform a final smoke test and go live.',
+        'Monitor analytics, Supabase logs, and Stripe alerts for rapid triage.'
+      ]
+    }
+  ];
+
+  output.log('Accelerated Launch Timeline');
+  output.log('-----------------------------');
+  blocks.forEach((block) => {
+    output.log(`• ${block.label}`);
+    block.tasks.forEach((task) => {
+      output.log(`   - ${task}`);
+    });
+    output.log('');
+  });
+  output.log('Reference docs/three-day-launch-plan.md for detailed context on each block.');
+}
+
+export async function gatherLaunchReadinessData() {
+  const readiness = await evaluateReadiness();
+  const envEntry = readiness.find((item) => item.id === 'env');
+  const envStatus = envEntry ? envEntry.detail : null;
+  const checklistGaps = await collectChecklistGaps();
+
+  return {
+    readiness,
+    envStatus,
+    checklistGaps
+  };
+}
+
+export async function runLaunchManager({ accelerated = false, output = console } = {}) {
+  const { readiness, envStatus, checklistGaps } = await gatherLaunchReadinessData();
+
+  if (!envStatus) {
+    throw new Error('Environment readiness entry missing from evaluation.');
+  }
+
+  output.log('🚀 mnnr.app Launch Manager');
+  output.log('============================\n');
+
+  output.log('Environment Configuration');
+  output.log('--------------------------');
+  output.log(formatEnvTable(envStatus));
+  if (envStatus.missing.length > 0) {
+    output.log('\nMissing variables:');
+    envStatus.missing.forEach((entry) => {
+      output.log(` - ${entry.key} [${entry.scope}]`);
+    });
+  }
+  output.log('\n');
+
+  output.log('Launch Critical Path');
+  output.log('---------------------');
+  readiness
+    .filter((item) => item.id !== 'env')
+    .forEach((item) => {
+      output.log(`${formatStatus(item.status)} ${item.label}`);
+      if (typeof item.detail === 'string') {
+        output.log(`   ${item.detail}`);
+      }
+      printDocsReminder(item.id, output);
+      output.log('');
+    });
+
+  output.log('Checklist Watch');
+  output.log('----------------');
+  if (checklistGaps.length === 0) {
+    output.log('All tracked checklists are ✅ complete.');
+  } else {
+    checklistGaps.forEach(({ source, items }) => {
+      output.log(`⚠️  ${source.label}`);
+      items.slice(0, 5).forEach((item) => {
+        const scope = item.heading ? ` (${item.heading})` : '';
+        output.log(`   • ${item.text}${scope}`);
+      });
+      if (items.length > 5) {
+        output.log(`   … and ${items.length - 5} more pending tasks`);
+      }
+      output.log('');
+    });
+    output.log('   ↳ Reference these documents to knock out remaining TODOs.');
+  }
+
+  output.log('Next Steps Guidance');
+  output.log('--------------------');
+  output.log('1. Apply database migrations and confirm RLS policies.');
+  output.log('2. Verify Stripe credentials and run webhook tests.');
+  output.log('3. Confirm legal pages and analytics scripts are deployed.');
+  output.log('4. Run end-to-end smoke test prior to launch.');
+
+  output.log('\nNeed more detail? Use the referenced documentation for step-by-step instructions.');
+
+  if (accelerated) {
+    output.log('\n');
+    printAcceleratedTimeline(output);
+  }
+
+  return { readiness, envStatus, checklistGaps };
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const options = parseLaunchManagerArgs(argv);
+
+  if (options.help) {
+    console.log('Usage: npm run launch:manager [-- [options]]');
+    console.log('Options:');
+    console.log('  -a, --accelerated   Append the compressed one-day launch timeline.');
+    console.log('  -h, --help          Show this help message.');
+    return;
+  }
+
+  await runLaunchManager({ accelerated: options.accelerated });
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error('Launch manager failed to run:', error);
+    process.exit(1);
+  });
+}
+
+export { parseLaunchManagerArgs };


### PR DESCRIPTION
## Summary
- add a launch executor CLI that applies the accelerated plan by auditing migrations, security, Stripe safeguards, analytics, and lint/build readiness in one run
- refactor the launch manager into reusable helpers, expose a new launch:execute npm script, and document the workflow in the launch sprint playbook
- fill the legal coverage gap with a refund policy page and resolve outstanding lint issues in global error handling, footer imports, and navbar auth fetching

## Testing
- npm run launch:execute

------
https://chatgpt.com/codex/tasks/task_b_68e580d8763883218e193fca89893119